### PR TITLE
Reproducible Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,24 @@ To see logs in attached debbuger (windbg), use `tracelog.exe` in administrator c
 * `tracelog -start MyTrace -guid #4970F9cf-2c0c-4f11-b1cc-e3a1e9958833 -rt -kd`
 
 
+### Reproducible builds
+
+Release builds of ovpn-dco-win are reproducible, meaning that when you use the same build environment, you should get the exact same ovpn-dco.sys binary. That way, you can verify that a driver released in binary form is indeed compiled from the source code in this repository. This is useful because Microsoft's driver signing requirements make it difficult to run self-compiled drivers.
+
+Released drivers are built with Windows 11 EWDK (Enterprise Windows Driver Kit). Despite the name, it also works on Windows 10.
+You can download it here: https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk
+
+If you have obtained a ovpn-dco.sys file, you can verify it as follows:
+
+1. Remove the signature from the ovpn-dco.sys file you received: `signtool remove /s ovpn-dco.sys`
+2. Clone this repository and check out the version that your file is supposed to be.
+3. Mount the Windows 11 EWDK iso image.
+4. In Powershell, navigate to the virtual drive and run `LaunchBuildEnv.cmd`.
+5. Navigate to the ovpn-dco-win project directory.
+6. Build the driver: `msbuild /p:platform=<arch> /p:configuration=release /p:signmode=off ovpn-dco-win.vcxproj /t:Build` where `<arch>` is `Win32`, `x64`, `ARM` or `ARM64`.
+7. Check that `<arch>/Release/ovpn-dco.sys` and the file from step 1 have the same SHA256 hash.
+
+
 ### Limitations
 
 * Minimum supported Windows version is Windows 10 20H1. This will unlikely to change.

--- a/driverhelper/driverhelper.vcxproj
+++ b/driverhelper/driverhelper.vcxproj
@@ -177,48 +177,51 @@
     <ClCompile>
       <WppEnabled>true</WppEnabled>
       <AdditionalIncludeDirectories>$(SolutionDir)dmf\dmf;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <WppScanConfigurationData>$(SolutionDir)driverhelper\tracewpp.h</WppScanConfigurationData>
+      <WppScanConfigurationData>$(ProjectDir)tracewpp.h</WppScanConfigurationData>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <WppEnabled>true</WppEnabled>
       <AdditionalIncludeDirectories>$(SolutionDir)dmf\dmf;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <WppScanConfigurationData>$(SolutionDir)driverhelper\tracewpp.h</WppScanConfigurationData>
+      <WppScanConfigurationData>$(ProjectDir)tracewpp.h</WppScanConfigurationData>
+      <UseFullPaths>false</UseFullPaths>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
       <WppEnabled>true</WppEnabled>
       <AdditionalIncludeDirectories>$(SolutionDir)dmf\dmf;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <WppScanConfigurationData>$(SolutionDir)driverhelper\tracewpp.h</WppScanConfigurationData>
+      <WppScanConfigurationData>$(ProjectDir)tracewpp.h</WppScanConfigurationData>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <ClCompile>
       <WppEnabled>true</WppEnabled>
       <AdditionalIncludeDirectories>$(SolutionDir)dmf\dmf;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <WppScanConfigurationData>$(SolutionDir)driverhelper\tracewpp.h</WppScanConfigurationData>
+      <WppScanConfigurationData>$(ProjectDir)tracewpp.h</WppScanConfigurationData>
+      <UseFullPaths>false</UseFullPaths>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WppEnabled>true</WppEnabled>
       <AdditionalIncludeDirectories>$(SolutionDir)dmf\dmf;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <WppScanConfigurationData>$(SolutionDir)driverhelper\tracewpp.h</WppScanConfigurationData>
+      <WppScanConfigurationData>$(ProjectDir)tracewpp.h</WppScanConfigurationData>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <WppEnabled>true</WppEnabled>
       <AdditionalIncludeDirectories>$(SolutionDir)dmf\dmf;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <WppScanConfigurationData>$(SolutionDir)driverhelper\tracewpp.h</WppScanConfigurationData>
+      <WppScanConfigurationData>$(ProjectDir)tracewpp.h</WppScanConfigurationData>
+      <UseFullPaths>false</UseFullPaths>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WppEnabled>true</WppEnabled>
-      <WppScanConfigurationData>$(SolutionDir)driverhelper\tracewpp.h</WppScanConfigurationData>
+      <WppScanConfigurationData>$(ProjectDir)tracewpp.h</WppScanConfigurationData>
       <EnablePREfast>true</EnablePREfast>
       <AdditionalIncludeDirectories>$(SolutionDir)dmf\dmf;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
@@ -227,7 +230,8 @@
     <ClCompile>
       <WppEnabled>true</WppEnabled>
       <AdditionalIncludeDirectories>$(SolutionDir)dmf\dmf;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <WppScanConfigurationData>$(SolutionDir)driverhelper\tracewpp.h</WppScanConfigurationData>
+      <WppScanConfigurationData>$(ProjectDir)tracewpp.h</WppScanConfigurationData>
+      <UseFullPaths>false</UseFullPaths>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/ovpn-cli/ovpn-cli.vcxproj
+++ b/ovpn-cli/ovpn-cli.vcxproj
@@ -141,13 +141,15 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <UseFullPaths>false</UseFullPaths>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
       <AdditionalDependencies>Iphlpapi.lib;ws2_32.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -190,13 +192,15 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <UseFullPaths>false</UseFullPaths>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
       <AdditionalDependencies>Iphlpapi.lib;ws2_32.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -209,13 +213,15 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <UseFullPaths>false</UseFullPaths>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
       <AdditionalDependencies>Iphlpapi.lib;ws2_32.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/ovpn-dco-win.vcxproj
+++ b/ovpn-dco-win.vcxproj
@@ -244,9 +244,13 @@
       <WppKernelMode>true</WppKernelMode>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>OVPN_DCO_VERSION_MAJOR=$(OVPN_DCO_VERSION_MAJOR);OVPN_DCO_VERSION_MINOR=$(OVPN_DCO_VERSION_MINOR);OVPN_DCO_VERSION_STR=$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>false</UseFullPaths>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Netio.lib;Bcrypt.lib;uuid.lib%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <Profile>false</Profile>
     </Link>
     <Inf>
       <TimeStamp>$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR)</TimeStamp>
@@ -283,9 +287,13 @@
       <WppKernelMode>true</WppKernelMode>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>OVPN_DCO_VERSION_MAJOR=$(OVPN_DCO_VERSION_MAJOR);OVPN_DCO_VERSION_MINOR=$(OVPN_DCO_VERSION_MINOR);OVPN_DCO_VERSION_STR=$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>false</UseFullPaths>
     </ClCompile>
     <Link>
       <AdditionalDependencies>uuid.lib;Netio.lib;Ksecdd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <Profile>false</Profile>
     </Link>
     <Inf>
       <TimeStamp>$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR)</TimeStamp>
@@ -313,9 +321,13 @@
       <WppKernelMode>true</WppKernelMode>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>OVPN_DCO_VERSION_MAJOR=$(OVPN_DCO_VERSION_MAJOR);OVPN_DCO_VERSION_MINOR=$(OVPN_DCO_VERSION_MINOR);OVPN_DCO_VERSION_STR=$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>false</UseFullPaths>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Netio.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <Profile>false</Profile>
     </Link>
     <Inf>
       <TimeStamp>$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR)</TimeStamp>
@@ -329,9 +341,13 @@
       <WppKernelMode>true</WppKernelMode>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>OVPN_DCO_VERSION_MAJOR=$(OVPN_DCO_VERSION_MAJOR);OVPN_DCO_VERSION_MINOR=$(OVPN_DCO_VERSION_MINOR);OVPN_DCO_VERSION_STR=$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>false</UseFullPaths>
     </ClCompile>
     <Link>
       <AdditionalDependencies>uuid.lib;Netio.lib;Ksecdd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <Profile>false</Profile>
     </Link>
     <Inf>
       <TimeStamp>$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR)</TimeStamp>

--- a/socket.cpp
+++ b/socket.cpp
@@ -47,7 +47,7 @@ OvpnSocketSyncOpCompletionRoutine(PDEVICE_OBJECT reserved, PIRP irp, PVOID conte
 }
 
 template <class OP, class SUCCESS>
-NTSTATUS
+__forceinline static NTSTATUS
 _Must_inspect_result_
 _IRQL_requires_(PASSIVE_LEVEL)
 OvpnSocketSyncOp(_In_z_ CHAR* opName, OP op, SUCCESS success)


### PR DESCRIPTION
I'm making this pull request for further comments. I asked on IRC on Friday, and people seem to prefer that I send the commits to the mailing list before they're included.

This pull request makes builds of ovpn-dco.sys reproducible by:
- configuring the compiler and linker for reproducible builds (including submodule update)
- force-inlineing a (template) function because its instantiations appeared in a non-deterministic order
- ~~including the expected hash for ovpn-dco.sys~~

~~I couldn't build the CLI exe yet.~~