### PR TITLE
Remove NetAdapterStop() call

### DIFF
--- a/Driver.cpp
+++ b/Driver.cpp
@@ -291,7 +291,9 @@ VOID OvpnEvtDeviceCleanup(WDFOBJECT obj) {
     OvpnBufferQueueDelete(device->ControlRxBufferQueue);
     OvpnBufferQueueDelete(device->DataRxBufferQueue);
 
-    OvpnAdapterDestroy(device->Adapter);
+    KIRQL irql = ExAcquireSpinLockExclusive(&device->SpinLock);
+    device->Adapter = WDF_NO_HANDLE;
+    ExReleaseSpinLockExclusive(&device->SpinLock, irql);
 }
 
 EVT_WDF_DRIVER_DEVICE_ADD OvpnEvtDeviceAdd;

--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>0</OVPN_DCO_VERSION_MAJOR>
     <OVPN_DCO_VERSION_MINOR>7</OVPN_DCO_VERSION_MINOR>
-    <OVPN_DCO_VERSION_PATCH>3</OVPN_DCO_VERSION_PATCH>
+    <OVPN_DCO_VERSION_PATCH>4</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>

--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>0</OVPN_DCO_VERSION_MAJOR>
     <OVPN_DCO_VERSION_MINOR>7</OVPN_DCO_VERSION_MINOR>
-    <OVPN_DCO_VERSION_PATCH>2</OVPN_DCO_VERSION_PATCH>
+    <OVPN_DCO_VERSION_PATCH>3</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>

--- a/adapter.cpp
+++ b/adapter.cpp
@@ -119,7 +119,9 @@ OvpnAdapterDestroy(NETADAPTER netAdapter)
     device->Adapter = WDF_NO_HANDLE;
     ExReleaseSpinLockExclusive(&device->SpinLock, irql);
 
-    NetAdapterStop(netAdapter);
+    // TODO: this breaks on Windows 10 when called from EvtCleanupCallback, is this call even needed?
+    // NetAdapterStop(netAdapter);
+
     WdfObjectDelete(netAdapter);
 }
 

--- a/adapter.cpp
+++ b/adapter.cpp
@@ -104,27 +104,6 @@ OvpnAdapterSetLinkState(POVPN_ADAPTER adapter, NET_IF_MEDIA_CONNECT_STATE state)
     NetAdapterSetLinkState(adapter->NetAdapter, &linkState);
 }
 
-
-_Use_decl_annotations_
-VOID
-OvpnAdapterDestroy(NETADAPTER netAdapter)
-{
-    if (netAdapter == WDF_NO_HANDLE)
-        return;
-
-    POVPN_ADAPTER adapter = OvpnGetAdapterContext(netAdapter);
-    POVPN_DEVICE device = OvpnGetDeviceContext(adapter->WdfDevice);
-
-    KIRQL irql = ExAcquireSpinLockExclusive(&device->SpinLock);
-    device->Adapter = WDF_NO_HANDLE;
-    ExReleaseSpinLockExclusive(&device->SpinLock, irql);
-
-    // TODO: this breaks on Windows 10 when called from EvtCleanupCallback, is this call even needed?
-    // NetAdapterStop(netAdapter);
-
-    WdfObjectDelete(netAdapter);
-}
-
 EVT_NET_ADAPTER_CREATE_TXQUEUE OvpnEvtAdapterCreateTxQueue;
 
 _Use_decl_annotations_

--- a/adapter.h
+++ b/adapter.h
@@ -48,10 +48,6 @@ _IRQL_requires_same_
 NTSTATUS
 OvpnAdapterCreate(OVPN_DEVICE* device);
 
-_IRQL_requires_(PASSIVE_LEVEL)
-VOID
-OvpnAdapterDestroy(NETADAPTER netAdapter);
-
 // notify NetAdapter (if it is ready) that more packets are available
 NTSTATUS
 OvpnAdapterNotifyRx(NETADAPTER netAdapter);


### PR DESCRIPTION
This breaks on Windows 10 when called from EvtCleanupCallback
and looks like it doesn't even required - device got deleted
and verifier doesn't bark.

Bump version to 0.7.3

Signed-off-by: Lev Stipakov <lev@openvpn.net>