### PR TITLE
Fix stats reporting

### DIFF
--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>0</OVPN_DCO_VERSION_MAJOR>
     <OVPN_DCO_VERSION_MINOR>8</OVPN_DCO_VERSION_MINOR>
-    <OVPN_DCO_VERSION_PATCH>2</OVPN_DCO_VERSION_PATCH>
+    <OVPN_DCO_VERSION_PATCH>3</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>


### PR DESCRIPTION
 - report TransportBytesSent for sent data channel packets
 - report TransportBytesReceived only for received control channel packets

Control channel packets are sent to userspace and accounted there.

Bump version to 0.8.3

Signed-off-by: Lev Stipakov <lev@openvpn.net>