### PR TITLE
Move WSK initialization into OVPN_IOCTL_NEW_PEER ioctl

### DIFF
--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -3,8 +3,8 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>0</OVPN_DCO_VERSION_MAJOR>
-    <OVPN_DCO_VERSION_MINOR>8</OVPN_DCO_VERSION_MINOR>
-    <OVPN_DCO_VERSION_PATCH>4</OVPN_DCO_VERSION_PATCH>
+    <OVPN_DCO_VERSION_MINOR>9</OVPN_DCO_VERSION_MINOR>
+    <OVPN_DCO_VERSION_PATCH>0</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>

--- a/bufferpool.cpp
+++ b/bufferpool.cpp
@@ -223,6 +223,9 @@ static
 VOID
 OvpnBufferPoolDelete(OVPN_BUFFER_POOL handle)
 {
+    if (handle == NULL)
+        return;
+
     OVPN_BUFFER_POOL_IMPL* pool = (OVPN_BUFFER_POOL_IMPL*)handle;
 
     LIST_ENTRY* list_entry = NULL;
@@ -277,6 +280,9 @@ OvpnRxBufferPoolCreate(OVPN_RX_BUFFER_POOL* handle)
 VOID
 OvpnBufferQueueDelete(OVPN_BUFFER_QUEUE handle)
 {
+    if (handle == NULL)
+        return;
+
     OVPN_BUFFER_QUEUE_IMPL* queue = (OVPN_BUFFER_QUEUE_IMPL*)handle;
 
     ExFreePoolWithTag(queue, 'ovpn');

--- a/peer.cpp
+++ b/peer.cpp
@@ -71,7 +71,7 @@ OvpnPeerNew(POVPN_DEVICE device, WDFREQUEST request)
     BOOLEAN proto_tcp = peer->Proto == OVPN_PROTO_TCP;
     SIZE_T remoteAddrSize = peer->Remote.Addr4.sin_family == AF_INET ? sizeof(peer->Remote.Addr4) : sizeof(peer->Remote.Addr6);
 
-    GOTO_IF_NOT_NT_SUCCESS(done, status, OvpnSocketInit(&driver->WskProviderNpi, peer->Local.Addr4.sin_family, proto_tcp, (PSOCKADDR)&peer->Local,
+    GOTO_IF_NOT_NT_SUCCESS(done, status, OvpnSocketInit(&driver->WskProviderNpi, &driver->WskRegistration, peer->Local.Addr4.sin_family, proto_tcp, (PSOCKADDR)&peer->Local,
         (PSOCKADDR)&peer->Remote, remoteAddrSize, device, &socket));
 
     BCRYPT_ALG_HANDLE aesAlgHandle = NULL, chachaAlgHandle = NULL;

--- a/socket.h
+++ b/socket.h
@@ -59,7 +59,7 @@ struct OvpnSocket
 _Must_inspect_result_
 _IRQL_requires_(PASSIVE_LEVEL)
 NTSTATUS
-OvpnSocketInit(_In_ WSK_PROVIDER_NPI* wskProviderNpi, ADDRESS_FAMILY addrFamily,
+OvpnSocketInit(_In_ WSK_PROVIDER_NPI* wskProviderNpi, _In_ WSK_REGISTRATION* wskRegistration, ADDRESS_FAMILY addrFamily,
 	BOOLEAN tcp, _In_ PSOCKADDR localAddr, _In_ PSOCKADDR remoteAddr, SIZE_T remoteAddrSize,
 	_In_ PVOID deviceContext, _Out_ PWSK_SOCKET* socket);
 


### PR DESCRIPTION
Having WskCaptureProviderNPI() call with WSK_INFINITE_WAIT argument in EvtDeviceAdd callback causes boot hang on some systems. It is not clear why it happens
and why majority of systems are fine.

Remove PnP Power callbacks, they're not relevant to us.

Bump version to 0.9.0.

Signed-off-by: Lev Stipakov <lev@openvpn.net>