### PR TITLE
Improve pool memory management

### DIFF
--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>0</OVPN_DCO_VERSION_MAJOR>
     <OVPN_DCO_VERSION_MINOR>9</OVPN_DCO_VERSION_MINOR>
-    <OVPN_DCO_VERSION_PATCH>3</OVPN_DCO_VERSION_PATCH>
+    <OVPN_DCO_VERSION_PATCH>4</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>

--- a/msm/installer.vcxproj
+++ b/msm/installer.vcxproj
@@ -31,7 +31,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{fda93664-ca76-44ef-89aa-625fbe9d64f6}</ProjectGuid>
     <RootNamespace>installer</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ovpn-cli/ovpn-cli.vcxproj
+++ b/ovpn-cli/ovpn-cli.vcxproj
@@ -32,7 +32,7 @@
     <ProjectGuid>{ba23900a-7fac-49cf-9ac7-c20cd52f42af}</ProjectGuid>
     <RootNamespace>ovpncli</RootNamespace>
     <ProjectName>ovpn-dco-cli</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
 - Handle case when IoAllocateMdl() and ExAllocatePool2() return NULL

 - Set max pool size (in-flight packets) to 100'000.

This might help with https://github.com/OpenVPN/ovpn-dco-win/issues/47

By playing with Quick Edit in console window (which makes execution stop) where iPerf3 was running I was able to get pool size growing to unreasonable values (over 50k). My understanding is that normally it should be <10k, but let's be on a safe side and cap it to 100k - in kernel dump it was over 1mil and system ran out of memory.

Bump to 0.9.4.