### PR TITLE
Move peer-specific data to separate struct

### DIFF
--- a/crypto.cpp
+++ b/crypto.cpp
@@ -263,16 +263,12 @@ OvpnCryptoNewKey(OvpnCryptoContext* cryptoContext, POVPN_CRYPTO_DATA cryptoData,
         keySlot->KeyId = cryptoData->KeyId;
         keySlot->PeerId = cryptoData->PeerId;
 
-        cryptoContext->CryptoOverhead = AEAD_CRYPTO_OVERHEAD;
-
         LOG_INFO("New key", TraceLoggingValue(cryptoData->CipherAlg == OVPN_CIPHER_ALG_AES_GCM ? "aes-gcm" : "chacha20-poly1305", "alg"),
             TraceLoggingValue(cryptoData->KeyId, "KeyId"), TraceLoggingValue(cryptoData->KeyId, "PeerId"));
     }
     else if (cryptoData->CipherAlg == OVPN_CIPHER_ALG_NONE) {
         cryptoContext->Encrypt = OvpnCryptoEncryptNone;
         cryptoContext->Decrypt = OvpnCryptoDecryptNone;
-
-        cryptoContext->CryptoOverhead = NONE_CRYPTO_OVERHEAD;
 
         LOG_INFO("Using cipher none");
     }

--- a/crypto.h
+++ b/crypto.h
@@ -2,6 +2,7 @@
  *  ovpn-dco-win OpenVPN protocol accelerator for Windows
  *
  *  Copyright (C) 2020-2021 OpenVPN Inc <sales@openvpn.net>
+ *  Copyright (C) 2023 Rubicon Communications LLC (Netgate)
  *
  *  Author:	Lev Stipakov <lev@openvpn.net>
  *

--- a/peer.h
+++ b/peer.h
@@ -2,6 +2,7 @@
  *  ovpn-dco-win OpenVPN protocol accelerator for Windows
  *
  *  Copyright (C) 2020-2021 OpenVPN Inc <sales@openvpn.net>
+ *  Copyright (C) 2023 Rubicon Communications LLC (Netgate)
  *
  *  Author:	Lev Stipakov <lev@openvpn.net>
  *
@@ -25,6 +26,36 @@
 
 #include "driver.h"
 #include "uapi\ovpn-dco.h"
+
+struct OvpnPeerContext
+{
+    OvpnCryptoContext CryptoContext;
+
+    INT32 PeerId;
+
+    // keepalive interval in seconds
+    LONG KeepaliveInterval;
+
+    // keepalive timeout in seconds
+    LONG KeepaliveTimeout;
+
+    // timer used to send periodic ping messages to the server if no data has been sent within the past KeepaliveInterval seconds
+    WDFTIMER KeepaliveXmitTimer;
+
+    // timer used to report keepalive timeout error to userspace when no data has been received for KeepaliveTimeout seconds
+    WDFTIMER KeepaliveRecvTimer;
+};
+
+_Must_inspect_result_
+OvpnPeerContext*
+OvpnPeerCtxAlloc();
+
+VOID
+OvpnPeerCtxFree(_In_ OvpnPeerContext*);
+
+RTL_GENERIC_ALLOCATE_ROUTINE OvpnPeerAllocateRoutine;
+RTL_GENERIC_FREE_ROUTINE OvpnPeerFreeRoutine;
+RTL_GENERIC_COMPARE_ROUTINE OvpnPeerCompareByPeerIdRoutine;
 
 _Must_inspect_result_
 _IRQL_requires_(PASSIVE_LEVEL)

--- a/rxqueue.cpp
+++ b/rxqueue.cpp
@@ -115,7 +115,7 @@ OvpnEvtRxQueueAdvance(NETPACKETQUEUE netPacketQueue)
         fragment->ValidLength = buffer->Len;
         fragment->Offset = 0;
         NET_FRAGMENT_VIRTUAL_ADDRESS* virtualAddr = NetExtensionGetFragmentVirtualAddress(&queue->VirtualAddressExtension, NetFragmentIteratorGetIndex(&fi));
-        RtlCopyMemory(virtualAddr->VirtualAddress, buffer->Data + device->CryptoContext.CryptoOverhead, buffer->Len);
+        RtlCopyMemory(virtualAddr->VirtualAddress, buffer->Data + device->CryptoOverhead, buffer->Len);
 
         InterlockedExchangeAddNoFence64(&device->Stats.TunBytesReceived, buffer->Len);
 

--- a/socket.h
+++ b/socket.h
@@ -66,7 +66,7 @@ OvpnSocketInit(_In_ WSK_PROVIDER_NPI* wskProviderNpi, _In_ WSK_REGISTRATION* wsk
 _Must_inspect_result_
 _IRQL_requires_(PASSIVE_LEVEL)
 NTSTATUS
-OvpnSocketClose(_In_ PWSK_SOCKET socket);
+OvpnSocketClose(_In_opt_ PWSK_SOCKET socket);
 
 _Must_inspect_result_
 NTSTATUS

--- a/timer.h
+++ b/timer.h
@@ -2,6 +2,7 @@
  *  ovpn-dco-win OpenVPN protocol accelerator for Windows
  *
  *  Copyright (C) 2020-2021 OpenVPN Inc <sales@openvpn.net>
+ *  Copyright (C) 2023 Rubicon Communications LLC (Netgate)
  *
  *  Author:	Lev Stipakov <lev@openvpn.net>
  *
@@ -29,11 +30,11 @@ OvpnTimerReset(WDFTIMER timer, ULONG dueTime);
 
 _Must_inspect_result_
 NTSTATUS
-OvpnTimerXmitCreate(WDFOBJECT parent, ULONG period, _Inout_ WDFTIMER* timer);
+OvpnTimerXmitCreate(WDFOBJECT parent, OvpnPeerContext* peer, ULONG period, _Inout_ WDFTIMER* timer);
 
 _Must_inspect_result_
 NTSTATUS
-OvpnTimerRecvCreate(WDFOBJECT parent, _Inout_ WDFTIMER* timer);
+OvpnTimerRecvCreate(WDFOBJECT parent, OvpnPeerContext* peer, _Inout_ WDFTIMER* timer);
 
 VOID
 OvpnTimerDestroy(_Inout_ WDFTIMER* timer);


### PR DESCRIPTION
In preparation to multipeer support, move peer-specific data from OVPN_DEVICE to OvpnPeerContext.

Peers (so far single one) are stored in splay tree, implemented with RTL_GENERIC_TABLE.

Fixes https://github.com/OpenVPN/ovpn-dco-win/issues/56.