### PR TITLE
crypto.c: ensure we don't pass too large key size to CryptoNG

### DIFF
--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>1</OVPN_DCO_VERSION_MAJOR>
     <OVPN_DCO_VERSION_MINOR>0</OVPN_DCO_VERSION_MINOR>
-    <OVPN_DCO_VERSION_PATCH>0</OVPN_DCO_VERSION_PATCH>
+    <OVPN_DCO_VERSION_PATCH>1</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>

--- a/crypto.cpp
+++ b/crypto.cpp
@@ -262,6 +262,14 @@ OvpnCryptoNewKey(OvpnCryptoContext* cryptoContext, POVPN_CRYPTO_DATA cryptoData)
             algHandle = cryptoContext->ChachaAlgHandle;
         }
 
+        if ((cryptoData->Encrypt.KeyLen > 32) || (cryptoData->Decrypt.KeyLen > 32))
+        {
+            status = STATUS_INVALID_DEVICE_REQUEST;
+            LOG_ERROR("Incorrect encrypt or decrypt key length", TraceLoggingValue(cryptoData->Encrypt.KeyLen, "Encrypt.KeyLen"),
+                TraceLoggingValue(cryptoData->Decrypt.KeyLen, "Decrypt.KeyLen"));
+            goto done;
+        }
+
         // generate keys from key materials
         GOTO_IF_NOT_NT_SUCCESS(done, status, BCryptGenerateSymmetricKey(algHandle, &keySlot->EncKey, NULL, 0, cryptoData->Encrypt.Key, cryptoData->Encrypt.KeyLen, 0));
         GOTO_IF_NOT_NT_SUCCESS(done, status, BCryptGenerateSymmetricKey(algHandle, &keySlot->DecKey, NULL, 0, cryptoData->Decrypt.Key, cryptoData->Decrypt.KeyLen, 0));


### PR DESCRIPTION
We use BCryptGenerateSymmetricKey() to generate a symmetric key object, passing a buffer containing a key and a key length. While buffer length is guaranteed not to exceed 32 bytes, the key length value is passed from userspace and could be at max 256 bytes.

The documentation says that:

  If the data passed in exceeds the target key size, the data will be truncated and the excess will be ignored.

which means that passing large length should not be a problem. I confirmed it with test with driver verifier enabled - I passed "256" as key length and haven't got any errors (and got key objected created and VPN session set up).

Nevertheless, let's be good citizens and error out if passed key length exceeds 32 bytes - maximum key length for AES-GCM and ChaCha20 ciphers.

Bump version to 1.0.1.

Reported-by: Vladimir Tokarev <vtokarev@microsoft.com>