### PR TITLE
timer: refactor timers implementation

### DIFF
--- a/Driver.h
+++ b/Driver.h
@@ -84,13 +84,9 @@ struct OVPN_DEVICE {
     _Guarded_by_(SpinLock)
     LONG KeepaliveTimeout;
 
-    // timer used to send periodic ping messages to the server if no data has been sent within the past KeepaliveInterval seconds
+    // 1-sec timer which handles ping intervals and keepalive timeouts
     _Guarded_by_(SpinLock)
-    WDFTIMER KeepaliveXmitTimer;
-
-    // timer used to report keepalive timeout error to userspace when no data has been received for KeepaliveTimeout seconds
-    _Guarded_by_(SpinLock)
-    WDFTIMER KeepaliveRecvTimer;
+    WDFTIMER Timer;
 
     // set from the userspace, defines TCP Maximum Segment Size
     _Guarded_by_(SpinLock)

--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -3,7 +3,7 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>1</OVPN_DCO_VERSION_MAJOR>
-    <OVPN_DCO_VERSION_MINOR>0</OVPN_DCO_VERSION_MINOR>
+    <OVPN_DCO_VERSION_MINOR>1</OVPN_DCO_VERSION_MINOR>
     <OVPN_DCO_VERSION_PATCH>1</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />

--- a/socket.cpp
+++ b/socket.cpp
@@ -194,7 +194,7 @@ VOID OvpnSocketDataPacketReceived(_In_ POVPN_DEVICE device, UCHAR op, _In_reads_
         return;
     }
 
-    OvpnTimerReset(device->KeepaliveRecvTimer, device->KeepaliveTimeout);
+    OvpnTimerResetRecv(device->Timer);
 
     // points to the beginning of plaintext
     UCHAR* buf = buffer->Data + device->CryptoContext.CryptoOverhead;

--- a/timer.h
+++ b/timer.h
@@ -25,15 +25,20 @@
 #include <wdf.h>
 
 VOID
-OvpnTimerReset(WDFTIMER timer, ULONG dueTime);
+OvpnTimerResetXmit(WDFTIMER timer);
+
+VOID
+OvpnTimerResetRecv(WDFTIMER timer);
 
 _Must_inspect_result_
 NTSTATUS
-OvpnTimerXmitCreate(WDFOBJECT parent, ULONG period, _Inout_ WDFTIMER* timer);
+OvpnTimerCreate(WDFOBJECT parent, _Inout_ WDFTIMER* timer);
 
-_Must_inspect_result_
-NTSTATUS
-OvpnTimerRecvCreate(WDFOBJECT parent, _Inout_ WDFTIMER* timer);
+VOID
+OvpnTimerSetXmitInterval(WDFTIMER timer, LONG xmitInterval);
+
+VOID
+OvpnTimerSetRecvTimeout(WDFTIMER timer, LONG recvTimeout);
 
 VOID
 OvpnTimerDestroy(_Inout_ WDFTIMER* timer);

--- a/txqueue.cpp
+++ b/txqueue.cpp
@@ -169,7 +169,7 @@ OvpnEvtTxQueueAdvance(NETPACKETQUEUE netPacketQueue)
 
     // reset keepalive timer
     if (packetSent) {
-        OvpnTimerReset(device->KeepaliveXmitTimer, device->KeepaliveInterval);
+        OvpnTimerResetXmit(device->Timer);
 
         if (!device->Socket.Tcp) {
             // this will use WskSendMessages to send buffers list which we constructed before


### PR DESCRIPTION
The current implementation uses "relative" WDF timers which are "not ticked" at low power states and on resume they continue to where they were left of. This makes keepalive timeout detection sub-optimal, since in worst case a client has to wait for "ping-restart" seconds to reconnect, which could be several minutes.

Refactor timers in a way that we only have single timer ticking every second. At that tick we compare "last" and "now" timestamps and do actions, similar to what openvpn2 is doing.

Fixes https://github.com/OpenVPN/ovpn-dco-win/issues/64