### PR TITLE
Fix bug check in timer management routines

### DIFF
--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -3,7 +3,7 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>1</OVPN_DCO_VERSION_MAJOR>
-    <OVPN_DCO_VERSION_MINOR>1</OVPN_DCO_VERSION_MINOR>
+    <OVPN_DCO_VERSION_MINOR>2</OVPN_DCO_VERSION_MINOR>
     <OVPN_DCO_VERSION_PATCH>1</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />

--- a/timer.cpp
+++ b/timer.cpp
@@ -170,8 +170,18 @@ NTSTATUS OvpnTimerCreate(WDFOBJECT parent, WDFTIMER* timer)
     return status;
 }
 
+#define CHECK_TIMER_HANDLE(timer) \
+    do { \
+        if ((timer) == WDF_NO_HANDLE) { \
+            LOG_ERROR("Timer handle is not initialized"); \
+            return; \
+        } \
+    } while (0)
+
 VOID OvpnTimerSetXmitInterval(WDFTIMER timer, LONG xmitInterval)
 {
+    CHECK_TIMER_HANDLE(timer);
+
     POVPN_TIMER_CONTEXT timerCtx = OvpnGetTimerContext(timer);
     timerCtx->xmitInterval = xmitInterval;
     KeQuerySystemTime(&timerCtx->lastXmit);
@@ -179,6 +189,8 @@ VOID OvpnTimerSetXmitInterval(WDFTIMER timer, LONG xmitInterval)
 
 VOID OvpnTimerSetRecvTimeout(WDFTIMER timer, LONG recvTimeout)
 {
+    CHECK_TIMER_HANDLE(timer);
+
     POVPN_TIMER_CONTEXT timerCtx = OvpnGetTimerContext(timer);
     timerCtx->recvTimeout = recvTimeout;
     KeQuerySystemTime(&timerCtx->lastRecv);
@@ -186,12 +198,16 @@ VOID OvpnTimerSetRecvTimeout(WDFTIMER timer, LONG recvTimeout)
 
 VOID OvpnTimerResetXmit(WDFTIMER timer)
 {
+    CHECK_TIMER_HANDLE(timer);
+
     POVPN_TIMER_CONTEXT timerCtx = OvpnGetTimerContext(timer);
     KeQuerySystemTime(&timerCtx->lastXmit);
 }
 
 VOID OvpnTimerResetRecv(WDFTIMER timer)
 {
+    CHECK_TIMER_HANDLE(timer);
+
     POVPN_TIMER_CONTEXT timerCtx = OvpnGetTimerContext(timer);
     KeQuerySystemTime(&timerCtx->lastRecv);
 }


### PR DESCRIPTION
Commit b750b2c ("timer: refactor timers implementation") has changed timer initialization logic and introduced a bug, where calling SET_PEER ioctl after failed NEW_PEER ioctl causes WDF_VIOLATION bug check, because we try to get a context of a WDF object which is NULL.

Fix by adding NULL checks.

Note that this is not expected to happen with openvpn as a driver client.

CVE: 2024-5198

Reported-By: Lukas Jokubauskas <lukas.jokubauskas@nordsec.com>