### PR TITLE
More robust way to get a version info

### DIFF
--- a/Driver.h
+++ b/Driver.h
@@ -47,6 +47,8 @@ EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL OvpnEvtIoDeviceControl;
 typedef struct _OVPN_DRIVER {
     WSK_PROVIDER_NPI WskProviderNpi;
     WSK_REGISTRATION WskRegistration;
+    WDFDEVICE ControlDevice;
+    LONG DeviceCount;
 } OVPN_DRIVER, * POVPN_DRIVER;
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(OVPN_DRIVER, OvpnGetDriverContext)
 

--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -3,8 +3,8 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>1</OVPN_DCO_VERSION_MAJOR>
-    <OVPN_DCO_VERSION_MINOR>2</OVPN_DCO_VERSION_MINOR>
-    <OVPN_DCO_VERSION_PATCH>1</OVPN_DCO_VERSION_PATCH>
+    <OVPN_DCO_VERSION_MINOR>3</OVPN_DCO_VERSION_MINOR>
+    <OVPN_DCO_VERSION_PATCH>0</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>

--- a/control.cpp
+++ b/control.cpp
@@ -1,0 +1,128 @@
+/*
+ *  ovpn-dco-win OpenVPN protocol accelerator for Windows
+ *
+ *  Copyright (C) 2024- OpenVPN Inc <sales@openvpn.net>
+ *
+ *  Author:	Lev Stipakov <lev@openvpn.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "control.h"
+#include "Driver.h"
+#include "uapi\ovpn-dco.h"
+#include "trace.h"
+
+_Use_decl_annotations_
+NTSTATUS
+OvpnGetVersion(WDFREQUEST request, ULONG_PTR* bytesReturned)
+{
+    LOG_ENTER();
+
+    *bytesReturned = 0;
+
+    NTSTATUS status;
+    POVPN_VERSION version = NULL;
+    GOTO_IF_NOT_NT_SUCCESS(done, status, WdfRequestRetrieveOutputBuffer(request, sizeof(OVPN_VERSION), (PVOID*)&version, NULL));
+
+    version->Major = OVPN_DCO_VERSION_MAJOR;
+    version->Minor = OVPN_DCO_VERSION_MINOR;
+    version->Patch = OVPN_DCO_VERSION_PATCH;
+
+    LOG_INFO("Version", TraceLoggingValue(version->Major, "Major"), TraceLoggingValue(version->Minor, "Minor"), TraceLoggingValue(version->Patch, "Patch"));
+
+    *bytesReturned = sizeof(OVPN_VERSION);
+
+done:
+    LOG_EXIT();
+
+    return status;
+}
+
+EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL OvpnEvtControlDeviceIOControl;
+
+VOID
+OvpnEvtControlDeviceIOControl(WDFQUEUE queue, WDFREQUEST request, size_t outputBufferLength, size_t inputBufferLength, ULONG ioControlCode)
+{
+    UNREFERENCED_PARAMETER(queue);
+    UNREFERENCED_PARAMETER(inputBufferLength);
+    UNREFERENCED_PARAMETER(outputBufferLength);
+
+    NTSTATUS status = STATUS_SUCCESS;
+    ULONG_PTR bytesReturned = 0;
+
+    switch (ioControlCode)
+    {
+    case OVPN_IOCTL_GET_VERSION:
+        status = OvpnGetVersion(request, &bytesReturned);
+        break;
+
+    default:
+        status = STATUS_INVALID_DEVICE_REQUEST;
+        break;
+    }
+
+    WdfRequestCompleteWithInformation(request, status, bytesReturned);
+}
+
+NTSTATUS
+OvpnCreateControlDevice(WDFDRIVER wdfDriver)
+{
+    LOG_ENTER();
+
+    DECLARE_CONST_UNICODE_STRING(symLink, L"\\DosDevices\\ovpn-dco-ver"); // this will be used by CreateFile
+    DECLARE_CONST_UNICODE_STRING(deviceName, L"\\Device\\ovpn-dco-ver"); // this is required tp create symlink
+
+    // allocate control device initialization structure
+    PWDFDEVICE_INIT deviceInit = WdfControlDeviceInitAllocate(wdfDriver, &SDDL_DEVOBJ_SYS_ALL_ADM_RWX_WORLD_R_RES_R);
+    if (deviceInit == NULL)
+    {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    // create the control device
+    WDF_OBJECT_ATTRIBUTES deviceAttributes;
+    WDF_OBJECT_ATTRIBUTES_INIT(&deviceAttributes);
+    WDFDEVICE controlDevice;
+    NTSTATUS status;
+
+    GOTO_IF_NOT_NT_SUCCESS(done, status, WdfDeviceInitAssignName(deviceInit, &deviceName));
+    GOTO_IF_NOT_NT_SUCCESS(done, status, WdfDeviceCreate(&deviceInit, &deviceAttributes, &controlDevice));
+
+    POVPN_DRIVER driverCtx = OvpnGetDriverContext(WdfGetDriver());
+    driverCtx->ControlDevice = controlDevice;
+
+    // symlink for control device
+    GOTO_IF_NOT_NT_SUCCESS(done, status, WdfDeviceCreateSymbolicLink(controlDevice, &symLink));
+
+    // queue to handle IO
+    WDF_IO_QUEUE_CONFIG queueConfig;
+    WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queueConfig, WdfIoQueueDispatchParallel);
+    queueConfig.EvtIoDeviceControl = OvpnEvtControlDeviceIOControl;
+    WDFQUEUE queue;
+    GOTO_IF_NOT_NT_SUCCESS(done, status, WdfIoQueueCreate(controlDevice, &queueConfig, WDF_NO_OBJECT_ATTRIBUTES, &queue));
+
+    // Complete the control device initialization
+    WdfControlFinishInitializing(controlDevice);
+
+ done:
+    if (deviceInit)
+    {
+        WdfDeviceInitFree(deviceInit);
+    }
+
+    LOG_EXIT();
+
+    return status;
+}

--- a/control.h
+++ b/control.h
@@ -1,0 +1,31 @@
+/*
+ *  ovpn-dco-win OpenVPN protocol accelerator for Windows
+ *
+ *  Copyright (C) 2024- OpenVPN Inc <sales@openvpn.net>
+ *
+ *  Author:	Lev Stipakov <lev@openvpn.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <ntddk.h>
+#include <wdf.h>
+
+NTSTATUS
+OvpnGetVersion(WDFREQUEST request, _Out_ ULONG_PTR* bytesReturned);
+
+NTSTATUS
+OvpnCreateControlDevice(WDFDRIVER wdfDriver);

--- a/ovpn-dco-win.vcxproj
+++ b/ovpn-dco-win.vcxproj
@@ -69,6 +69,7 @@
   <ItemGroup>
     <ClCompile Include="adapter.cpp" />
     <ClCompile Include="bufferpool.cpp" />
+    <ClCompile Include="control.cpp" />
     <ClCompile Include="crypto.cpp" />
     <ClCompile Include="driver.cpp" />
     <ClCompile Include="mss.cpp" />
@@ -82,6 +83,7 @@
   <ItemGroup>
     <ClInclude Include="adapter.h" />
     <ClInclude Include="bufferpool.h" />
+    <ClInclude Include="control.h" />
     <ClInclude Include="crypto.h" />
     <ClInclude Include="driver.h" />
     <ClInclude Include="mss.h" />
@@ -440,7 +442,7 @@
       <PreprocessorDefinitions>OVPN_DCO_VERSION_MAJOR=$(OVPN_DCO_VERSION_MAJOR);OVPN_DCO_VERSION_MINOR=$(OVPN_DCO_VERSION_MINOR);OVPN_DCO_VERSION_PATCH=$(OVPN_DCO_VERSION_PATCH);OVPN_DCO_VERSION_STR=$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR).$(OVPN_DCO_VERSION_PATCH);NETADAPTER_VERSION_MAJOR=$(NETADAPTER_VERSION_MAJOR);NETADAPTER_VERSION_MINOR=$(NETADAPTER_VERSION_MINOR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Inf />
     <DriverSign>
@@ -456,7 +458,7 @@
       <PreprocessorDefinitions>OVPN_DCO_VERSION_MAJOR=$(OVPN_DCO_VERSION_MAJOR);OVPN_DCO_VERSION_MINOR=$(OVPN_DCO_VERSION_MINOR);OVPN_DCO_VERSION_PATCH=$(OVPN_DCO_VERSION_PATCH);OVPN_DCO_VERSION_STR=$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR).$(OVPN_DCO_VERSION_PATCH);NETADAPTER_VERSION_MAJOR=$(NETADAPTER_VERSION_MAJOR);NETADAPTER_VERSION_MINOR=$(NETADAPTER_VERSION_MINOR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Inf />
     <DriverSign>
@@ -478,7 +480,7 @@
       <Outputs>$(ProjectDir)$(Platform)\$(ConfigurationName)\ovpn-dco.DVL.XML</Outputs>
     </CustomBuildStep>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <Profile>false</Profile>
@@ -505,7 +507,7 @@
       <Outputs>$(ProjectDir)$(Platform)\$(ConfigurationName)\ovpn-dco.DVL.XML</Outputs>
     </CustomBuildStep>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <Profile>false</Profile>
@@ -526,7 +528,7 @@
       <PreprocessorDefinitions>OVPN_DCO_VERSION_MAJOR=$(OVPN_DCO_VERSION_MAJOR);OVPN_DCO_VERSION_MINOR=$(OVPN_DCO_VERSION_MINOR);OVPN_DCO_VERSION_PATCH=$(OVPN_DCO_VERSION_PATCH);OVPN_DCO_VERSION_STR=$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR).$(OVPN_DCO_VERSION_PATCH);NETADAPTER_VERSION_MAJOR=$(NETADAPTER_VERSION_MAJOR);NETADAPTER_VERSION_MINOR=$(NETADAPTER_VERSION_MINOR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>
@@ -550,7 +552,7 @@
       <PreprocessorDefinitions>OVPN_DCO_VERSION_MAJOR=$(OVPN_DCO_VERSION_MAJOR);OVPN_DCO_VERSION_MINOR=$(OVPN_DCO_VERSION_MINOR);OVPN_DCO_VERSION_PATCH=$(OVPN_DCO_VERSION_PATCH);OVPN_DCO_VERSION_STR=$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR).$(OVPN_DCO_VERSION_PATCH);NETADAPTER_VERSION_MAJOR=$(NETADAPTER_VERSION_MAJOR);NETADAPTER_VERSION_MINOR=$(NETADAPTER_VERSION_MINOR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>
@@ -580,7 +582,7 @@
       <Outputs>$(ProjectDir)$(Platform)\$(ConfigurationName)\ovpn-dco.DVL.XML</Outputs>
     </CustomBuildStep>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <Profile>false</Profile>
@@ -607,7 +609,7 @@
       <Outputs>$(ProjectDir)$(Platform)\$(ConfigurationName)\ovpn-dco.DVL.XML</Outputs>
     </CustomBuildStep>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <Profile>false</Profile>
@@ -628,7 +630,7 @@
       <PreprocessorDefinitions>OVPN_DCO_VERSION_MAJOR=$(OVPN_DCO_VERSION_MAJOR);OVPN_DCO_VERSION_MINOR=$(OVPN_DCO_VERSION_MINOR);OVPN_DCO_VERSION_PATCH=$(OVPN_DCO_VERSION_PATCH);OVPN_DCO_VERSION_STR=$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR).$(OVPN_DCO_VERSION_PATCH);NETADAPTER_VERSION_MAJOR=$(NETADAPTER_VERSION_MAJOR);NETADAPTER_VERSION_MINOR=$(NETADAPTER_VERSION_MINOR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Inf />
     <DriverSign>
@@ -644,7 +646,7 @@
       <PreprocessorDefinitions>OVPN_DCO_VERSION_MAJOR=$(OVPN_DCO_VERSION_MAJOR);OVPN_DCO_VERSION_MINOR=$(OVPN_DCO_VERSION_MINOR);OVPN_DCO_VERSION_PATCH=$(OVPN_DCO_VERSION_PATCH);OVPN_DCO_VERSION_STR=$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR).$(OVPN_DCO_VERSION_PATCH);NETADAPTER_VERSION_MAJOR=$(NETADAPTER_VERSION_MAJOR);NETADAPTER_VERSION_MINOR=$(NETADAPTER_VERSION_MINOR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Inf />
     <DriverSign>
@@ -661,7 +663,7 @@
       <UseFullPaths>false</UseFullPaths>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <Profile>false</Profile>
@@ -683,7 +685,7 @@
       <UseFullPaths>false</UseFullPaths>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <Profile>false</Profile>
@@ -710,7 +712,7 @@
       <Outputs>$(ProjectDir)$(Platform)\$(ConfigurationName)\ovpn-dco.DVL.XML</Outputs>
     </CustomBuildStep>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <Profile>false</Profile>
@@ -737,7 +739,7 @@
       <Outputs>$(ProjectDir)$(Platform)\$(ConfigurationName)\ovpn-dco.DVL.XML</Outputs>
     </CustomBuildStep>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <Profile>false</Profile>
@@ -758,7 +760,7 @@
       <PreprocessorDefinitions>OVPN_DCO_VERSION_MAJOR=$(OVPN_DCO_VERSION_MAJOR);OVPN_DCO_VERSION_MINOR=$(OVPN_DCO_VERSION_MINOR);OVPN_DCO_VERSION_PATCH=$(OVPN_DCO_VERSION_PATCH);OVPN_DCO_VERSION_STR=$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR).$(OVPN_DCO_VERSION_PATCH);NETADAPTER_VERSION_MAJOR=$(NETADAPTER_VERSION_MAJOR);NETADAPTER_VERSION_MINOR=$(NETADAPTER_VERSION_MINOR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Inf />
     <DriverSign>
@@ -774,7 +776,7 @@
       <PreprocessorDefinitions>OVPN_DCO_VERSION_MAJOR=$(OVPN_DCO_VERSION_MAJOR);OVPN_DCO_VERSION_MINOR=$(OVPN_DCO_VERSION_MINOR);OVPN_DCO_VERSION_PATCH=$(OVPN_DCO_VERSION_PATCH);OVPN_DCO_VERSION_STR=$(OVPN_DCO_VERSION_MAJOR).$(OVPN_DCO_VERSION_MINOR).$(OVPN_DCO_VERSION_PATCH);NETADAPTER_VERSION_MAJOR=$(NETADAPTER_VERSION_MAJOR);NETADAPTER_VERSION_MINOR=$(NETADAPTER_VERSION_MINOR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;Netio.lib;cng.lib;wdmsec.lib%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Inf />
     <DriverSign>

--- a/ovpn-dco-win.vcxproj.filters
+++ b/ovpn-dco-win.vcxproj.filters
@@ -67,6 +67,9 @@
     <ClInclude Include="mss.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="control.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="driver.cpp">
@@ -100,6 +103,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="mss.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="control.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
The current way to get a version information is to open DCO device and make IOCTL call. This has a few issues:

 - If DCO device is already in use, an another app won't be to get the version, since the device is exclusive

 - With the multiple DCO devices there is a high chance that \\.\ovpn-dco device, which we use to get version information, is already in use. To open another device, we use via device interface enumeration, which requires a lot of boilerplate code to work.

To make it easier for userspace to get the device version, create a non-exclusive control device \\.\ovpn-dco-ver which supports single IOCTL to get the version number. This device is created when the first network device is created and removed with the last network device.

Bump version to 1.3.0.

https://github.com/OpenVPN/ovpn-dco-win/issues/75