### PR TITLE
Fix routing loops when default route is lost in full-tunnel VPN

### DIFF
--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>2</OVPN_DCO_VERSION_MAJOR>
     <OVPN_DCO_VERSION_MINOR>5</OVPN_DCO_VERSION_MINOR>
-    <OVPN_DCO_VERSION_PATCH>5</OVPN_DCO_VERSION_PATCH>
+    <OVPN_DCO_VERSION_PATCH>6</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>

--- a/txqueue.cpp
+++ b/txqueue.cpp
@@ -64,6 +64,91 @@ OvpnTxAreSockaddrEqual(const SOCKADDR* addr1, const SOCKADDR* addr2) {
     return 0;
 }
 
+BOOLEAN
+OvpnCheckRecursiveRoutingIPv4(SOCKADDR_IN* transportAdds, UCHAR* buffer, SIZE_T bufferLength, BOOLEAN tcp)
+{
+    if (transportAdds->sin_family != AF_INET || bufferLength < sizeof(IPV4_HEADER))
+        return FALSE;  // Not an IPv4 peer or packet too short
+
+    // Extract pointers to avoid repeated FIELD_OFFSET calculations
+    IN_ADDR* srcAddr = (IN_ADDR*)(buffer + FIELD_OFFSET(IPV4_HEADER, SourceAddress));
+    IN_ADDR* dstAddr = (IN_ADDR*)(buffer + FIELD_OFFSET(IPV4_HEADER, DestinationAddress));
+    UINT8 packetProtocol = buffer[FIELD_OFFSET(IPV4_HEADER, Protocol)];
+
+    // Validate the transport protocol
+    if ((tcp && packetProtocol != IPPROTO_TCP) || (!tcp && packetProtocol != IPPROTO_UDP))
+        return FALSE;
+
+    // Extract IP header length
+    UINT8 ipHeaderLength = (buffer[0] & 0x0F) << 2;
+
+    // Ensure transport header is accessible
+    if (bufferLength < ipHeaderLength + sizeof(UINT16) * 2)
+        return FALSE;
+
+    // Read transport header efficiently
+    UCHAR* transportHeader = buffer + ipHeaderLength;
+    UINT16 packetSrcPort = RtlUshortByteSwap(*(UINT16*)(transportHeader));
+    UINT16 packetDstPort = RtlUshortByteSwap(*(UINT16*)(transportHeader + 2));
+    UINT16 peerPort = RtlUshortByteSwap(transportAdds->sin_port);
+
+    // Check for recursive routing
+    if (packetDstPort == peerPort &&
+        RtlCompareMemory(dstAddr, &transportAdds->sin_addr, sizeof(IN_ADDR)) == sizeof(IN_ADDR))
+    {
+        LOG_WARN("Recursive routing detected (IPv4), packet dropped",
+            TraceLoggingIPv4Address(srcAddr->S_un.S_addr, "saddr"),
+            TraceLoggingIPv4Address(dstAddr->S_un.S_addr, "daddr"),
+            TraceLoggingUInt16(packetSrcPort, "sport"),
+            TraceLoggingUInt16(packetDstPort, "dport"),
+            TraceLoggingUInt8(packetProtocol, "protocol"));
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+BOOLEAN
+OvpnCheckRecursiveRoutingIPv6(SOCKADDR_IN6* transportAddr, UCHAR* buffer, SIZE_T bufferLength, BOOLEAN tcp)
+{
+    if (transportAddr->sin6_family != AF_INET6 || bufferLength < sizeof(IPV6_HEADER))
+        return FALSE;  // Not an IPv6 peer or packet too short
+
+    // Extract pointers to avoid repeated FIELD_OFFSET calculations
+    IN6_ADDR* srcAddr = (IN6_ADDR*)(buffer + FIELD_OFFSET(IPV6_HEADER, SourceAddress));
+    IN6_ADDR* dstAddr = (IN6_ADDR*)(buffer + FIELD_OFFSET(IPV6_HEADER, DestinationAddress));
+    UINT8 packetProtocol = buffer[FIELD_OFFSET(IPV6_HEADER, NextHeader)];
+
+    // Validate the transport protocol
+    if ((tcp && packetProtocol != IPPROTO_TCP) || (!tcp && packetProtocol != IPPROTO_UDP))
+        return FALSE;
+
+    // Ensure transport header is accessible
+    if (bufferLength < sizeof(IPV6_HEADER) + sizeof(UINT16) * 2)
+        return FALSE;
+
+    // Read transport header efficiently
+    UCHAR* transportHeader = buffer + sizeof(IPV6_HEADER);
+    UINT16 packetSrcPort = RtlUshortByteSwap(*(UINT16*)(transportHeader));
+    UINT16 packetDstPort = RtlUshortByteSwap(*(UINT16*)(transportHeader + 2));
+    UINT16 peerPort = RtlUshortByteSwap(transportAddr->sin6_port);
+
+    // Check for recursive routing
+    if (packetDstPort == peerPort &&
+        RtlCompareMemory(dstAddr, &transportAddr->sin6_addr, sizeof(IN6_ADDR)) == sizeof(IN6_ADDR))
+    {
+        LOG_WARN("Recursive routing detected (IPv6), packet dropped",
+            TraceLoggingIPv6Address(srcAddr->u.Byte, "saddr"),
+            TraceLoggingIPv6Address(dstAddr->u.Byte, "daddr"),
+            TraceLoggingUInt16(packetSrcPort, "sport"),
+            TraceLoggingUInt16(packetDstPort, "dport"),
+            TraceLoggingUInt8(packetProtocol, "protocol"));
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
 _Must_inspect_result_
 static
 NTSTATUS
@@ -114,6 +199,11 @@ OvpnTxProcessPacket(_In_ POVPN_DEVICE device, _In_ POVPN_TXQUEUE queue, _In_ NET
             peer = device->IRoutesIPV4.Find(reinterpret_cast<UCHAR*>(&addr));
         }
 
+        if ((device->Mode == OVPN_MODE_P2P) && (peer != nullptr) && (OvpnCheckRecursiveRoutingIPv4(&peer->TransportAddrs.Remote.IPv4, buffer->Data, buffer->Len, device->Socket.Tcp))) {
+            OvpnPeerCtxRelease(peer);
+            peer = nullptr;
+        }
+
         if (peer != nullptr) {
             OvpnMssDoIPv4(buffer->Data, buffer->Len, peer->MSS);
         }
@@ -123,6 +213,11 @@ OvpnTxProcessPacket(_In_ POVPN_DEVICE device, _In_ POVPN_TXQUEUE queue, _In_ NET
         peer = OvpnFindPeerVPN6(device, addr);
         if (peer == nullptr) {
             peer = device->IRoutesIPV6.Find(reinterpret_cast<UCHAR*>(&addr));
+        }
+
+        if ((device->Mode == OVPN_MODE_P2P) && (peer != nullptr) && (OvpnCheckRecursiveRoutingIPv6(&peer->TransportAddrs.Remote.IPv6, buffer->Data, buffer->Len, device->Socket.Tcp))) {
+            OvpnPeerCtxRelease(peer);
+            peer = nullptr;
         }
 
         if (peer != nullptr) {


### PR DESCRIPTION
Added checks to detect and drop OpenVPN’s own encrypted traffic when it gets mistakenly routed back through the VPN tunnel.

This happens when the default route is removed or the network adapter is disabled while a full-tunnel VPN is active. Without a proper route to the internet, OpenVPN’s outgoing traffic can end up going through the tunnel itself, creating a loop that breaks connectivity.

Now, we compare the destination IP and port against the peer’s transport address to catch and drop these packets before they cause issues.

https://github.com/OpenVPN/ovpn-dco-win/issues/102

Bump to 2.5.6.