### PR TITLE
multipeer: fix iroute removal

### DIFF
--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>2</OVPN_DCO_VERSION_MAJOR>
     <OVPN_DCO_VERSION_MINOR>5</OVPN_DCO_VERSION_MINOR>
-    <OVPN_DCO_VERSION_PATCH>7</OVPN_DCO_VERSION_PATCH>
+    <OVPN_DCO_VERSION_PATCH>8</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>

--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>2</OVPN_DCO_VERSION_MAJOR>
     <OVPN_DCO_VERSION_MINOR>5</OVPN_DCO_VERSION_MINOR>
-    <OVPN_DCO_VERSION_PATCH>6</OVPN_DCO_VERSION_PATCH>
+    <OVPN_DCO_VERSION_PATCH>7</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>

--- a/trie.cpp
+++ b/trie.cpp
@@ -144,6 +144,8 @@ IPTrie::Insert(const UCHAR* ip, int prefixLength, OvpnPeerContext* peer) {
     // increment peer refcnt since it has been stored in a trie
     InterlockedIncrement(&peer->RefCounter);
 
+    LOG_INFO("Peer node", TraceLoggingValue(peer->PeerId, "peerId"));
+
     ExReleaseSpinLockExclusive(&Lock, kirql);
 
 done:
@@ -184,8 +186,6 @@ IPTrie::Find(const UCHAR* ip) {
 
 VOID
 IPTrie::RemoveByPeerId(INT32 peerId) {
-    LOG_ENTER();
-
     LIST_ENTRY cleanupList;
     InitializeListHead(&cleanupList);
 
@@ -201,8 +201,6 @@ IPTrie::RemoveByPeerId(INT32 peerId) {
         OvpnPeerContext* peer = CONTAINING_RECORD(entry, OvpnPeerContext, ListEntry);
         OvpnPeerCtxRelease(peer);
     }
-
-    LOG_EXIT();
 }
 
 IPTrie::TrieNode*
@@ -223,6 +221,8 @@ IPTrie::RemoveByPeerId(TrieNode* node, INT32 peerId, PLIST_ENTRY cleanupList) {
 
         node->peer = nullptr;
         node->isRoute = false;
+
+        LOG_INFO("Peer node", TraceLoggingValue(peerId, "peerId"));
     }
 
     // If this node has no children and is no longer a route, delete it
@@ -243,7 +243,7 @@ IPTrie::Remove(const UCHAR* ip, int prefixLength) {
     OvpnPeerContext* peerToRelease = nullptr;
 
     KIRQL oldIrql = ExAcquireSpinLockExclusive(&Lock);
-    root = RemoveRouteNode(root, ip, prefixLength, &peerToRelease);
+    root = RemoveRouteNode(root, ip, prefixLength, 0, &peerToRelease);
     ExReleaseSpinLockExclusive(&Lock, oldIrql);
 
     // Release the peer outside the lock if needed
@@ -255,16 +255,17 @@ IPTrie::Remove(const UCHAR* ip, int prefixLength) {
 }
 
 IPTrie::TrieNode*
-IPTrie::RemoveRouteNode(TrieNode* node, const UCHAR* ip, int prefixLength, OvpnPeerContext** peerToRelease) {
+IPTrie::RemoveRouteNode(TrieNode* node, const UCHAR* ip, int prefixLength, int depth, OvpnPeerContext** peerToRelease) {
     if (!node) return nullptr;
 
-    if (prefixLength > 0) {
-        int bit = (ip[(maxBits - prefixLength) / 8] >> (7 - ((maxBits - prefixLength) % 8))) & 1;
-        node->children[bit] = RemoveRouteNode(node->children[bit], ip, prefixLength - 1, peerToRelease);
+    if (depth < prefixLength) {
+        int bit = (ip[depth / 8] >> (7 - (depth % 8))) & 1;
+        node->children[bit] = RemoveRouteNode(node->children[bit], ip, prefixLength, depth + 1, peerToRelease);
     }
     else {
         if (node->peer) {
             *peerToRelease = node->peer;
+            LOG_INFO("Peer node", TraceLoggingValue(node->peer->PeerId));
             node->peer = nullptr;
         }
         node->isRoute = false;

--- a/trie.h
+++ b/trie.h
@@ -56,7 +56,7 @@ private:
     EX_SPIN_LOCK Lock = 0; // Lock for shared/exclusive access
 
     TrieNode* RemoveByPeerId(TrieNode* node, INT32 peerId, PLIST_ENTRY cleanupList);
-    TrieNode* RemoveRouteNode(TrieNode* node, const UCHAR* ip, int prefixLength, OvpnPeerContext** peerToRelease);
+    TrieNode* RemoveRouteNode(TrieNode* node, const UCHAR* ip, int prefixLength, int depth, OvpnPeerContext** peerToRelease);
 
     VOID FreeTrie(TrieNode* node);
     VOID CleanupNode(TrieNode* node, PLIST_ENTRY cleanupList);

--- a/txqueue.cpp
+++ b/txqueue.cpp
@@ -324,6 +324,10 @@ OvpnEvtTxQueueAdvance(NETPACKETQUEUE netPacketQueue)
     POVPN_DEVICE device = OvpnGetDeviceContext(queue->Adapter->WdfDevice);
     BOOLEAN packetSent = false;
 
+    KIRQL kirql = ExAcquireSpinLockShared(&device->SpinLock);
+    BOOLEAN isTcp = device->Socket.Tcp;
+    ExReleaseSpinLockShared(&device->SpinLock, kirql);
+
     OVPN_TX_BUFFER* txBufferHead = NULL;
     OVPN_TX_BUFFER* txBufferTail = NULL;
     SOCKADDR_STORAGE headSockaddr = {0};
@@ -348,11 +352,9 @@ OvpnEvtTxQueueAdvance(NETPACKETQUEUE netPacketQueue)
     }
     NetPacketIteratorSet(&pi);
 
-    if (packetSent) {
-        if (!device->Socket.Tcp) {
-            // this will use WskSendMessages to send buffers list which we constructed before
-            LOG_IF_NOT_NT_SUCCESS(OvpnSocketSend(&device->Socket, txBufferHead, (SOCKADDR*)&headSockaddr));
-        }
+    if (packetSent && !isTcp && txBufferHead != NULL) {
+        // this will use WskSendMessages to send buffers list which we constructed before
+        LOG_IF_NOT_NT_SUCCESS(OvpnSocketSend(&device->Socket, txBufferHead, (SOCKADDR*)&headSockaddr));
     }
 }
 


### PR DESCRIPTION
When inserting a peer node into the iroute trie, we traverse
the bits starting from the most significant bit. However,
when removing a node by route, we previously traversed
in the opposite direction. This inconsistency could prevent us
from reaching the intended node, leaving a stale entry in the trie.

Fortunately, after sending the IOCTL to remove an iroute
by route, userspace always follows up with another IOCTL
to remove the peer, which in turn removes the iroute by
peer ID. As a result, the stale node is typically cleaned up anyway.

However, since the API allows iroute removal by route
independently, we cannot assume that userspace will always
remove the peer afterward. Therefore, we fix this by ensuring that
iroute removal traverses the trie in the same direction as insertion.

Github: https://github.com/OpenVPN/ovpn-dco-win/issues/105

Bump version to 2.5.7.