### PR TITLE
2.5.9

### DIFF
--- a/Driver.cpp
+++ b/Driver.cpp
@@ -239,6 +239,12 @@ OvpnEvtIoWrite(WDFQUEUE queue, WDFREQUEST request, size_t length)
     // fetch tx buffer
     GOTO_IF_NOT_NT_SUCCESS(error, status, OvpnTxBufferPoolGet(device->TxBufferPool, &txBuf));
 
+    if (bufLen > OVPN_DCO_MTU_MAX) {
+        status = STATUS_INVALID_BUFFER_SIZE;
+        LOG_ERROR("Control message exceeds maximum size", TraceLoggingValue(bufLen, "msgLen"), TraceLoggingValue(OVPN_DCO_MTU_MAX, "max"));
+        goto error;
+    }
+
     // copy data from request to tx buffer
     PUCHAR data = OvpnBufferPut(txBuf, bufLen);
     RtlCopyMemory(data, buf, bufLen);

--- a/Driver.cpp
+++ b/Driver.cpp
@@ -488,14 +488,26 @@ OvpnMPAddIRoute(POVPN_DEVICE device, WDFREQUEST request) {
             TraceLoggingIPv6Address(&iroute->Addr.Addr6, "network"),
             TraceLoggingValue(iroute->Netbits, "netbits"));
 
-        status = device->IRoutesIPV6.Insert(reinterpret_cast<UCHAR*>(&iroute->Addr.Addr6), iroute->Netbits, peer);
+        if (iroute->Netbits < 0 || iroute->Netbits > 128) {
+            LOG_ERROR("Invalid Netbits", TraceLoggingValue(iroute->Netbits, "netbits"));
+            status = STATUS_INVALID_PARAMETER;
+        }
+        else {
+            status = device->IRoutesIPV6.Insert(reinterpret_cast<UCHAR*>(&iroute->Addr.Addr6), iroute->Netbits, peer);
+        }
     }
     else {
         LOG_INFO("Add IPV4 iroute", TraceLoggingValue(iroute->PeerId, "peer-id"),
             TraceLoggingIPv4Address(iroute->Addr.Addr4.S_un.S_addr, "network"),
             TraceLoggingValue(iroute->Netbits, "netbits"));
 
-        status = device->IRoutesIPV4.Insert(reinterpret_cast<UCHAR*>(&iroute->Addr.Addr4), iroute->Netbits, peer);
+        if (iroute->Netbits < 0 || iroute->Netbits > 32) {
+            LOG_ERROR("Invalid Netbits", TraceLoggingValue(iroute->Netbits, "netbits"));
+            status = STATUS_INVALID_PARAMETER;
+        }
+        else {
+            status = device->IRoutesIPV4.Insert(reinterpret_cast<UCHAR*>(&iroute->Addr.Addr4), iroute->Netbits, peer);
+        }
     }
 
     if (peer != nullptr) {

--- a/Driver.cpp
+++ b/Driver.cpp
@@ -406,6 +406,15 @@ OvpnMPStartVPN(POVPN_DEVICE device, WDFREQUEST request, ULONG_PTR* bytesReturned
         POVPN_MP_START_VPN addrIn = NULL;
         GOTO_IF_NOT_NT_SUCCESS(done, status, WdfRequestRetrieveInputBuffer(request, sizeof(OVPN_MP_START_VPN), (PVOID*)&addrIn, NULL));
 
+        if ((addrIn->ListenAddress.Addr4.sin_family != AF_INET) &&
+            (addrIn->ListenAddress.Addr4.sin_family != AF_INET6))
+        {
+            status = STATUS_INVALID_DEVICE_REQUEST;
+            LOG_ERROR("Unknown address family in ListenAddress",
+                TraceLoggingValue(addrIn->ListenAddress.Addr4.sin_family, "AF"));
+            goto done;
+        }
+
         PWSK_SOCKET socket = NULL;
         POVPN_DRIVER driver = OvpnGetDriverContext(WdfGetDriver());
 

--- a/PropertySheet.props
+++ b/PropertySheet.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <OVPN_DCO_VERSION_MAJOR>2</OVPN_DCO_VERSION_MAJOR>
     <OVPN_DCO_VERSION_MINOR>5</OVPN_DCO_VERSION_MINOR>
-    <OVPN_DCO_VERSION_PATCH>8</OVPN_DCO_VERSION_PATCH>
+    <OVPN_DCO_VERSION_PATCH>9</OVPN_DCO_VERSION_PATCH>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>

--- a/gui/gui.cpp
+++ b/gui/gui.cpp
@@ -596,7 +596,7 @@ CreatePushButton(HWND hWnd, wchar_t* title, HMENU hMenu, int x, int y)
 HWND
 CreateEditBox(HWND hWnd, WCHAR* text, int x, int y, int width)
 {
-    return CreateWindowW(L"Edit", text, WS_VISIBLE | WS_CHILD | WS_BORDER | ES_LEFT, x, y, width, 20, hWnd, NULL, NULL, NULL);
+    return CreateWindowW(L"Edit", text, WS_VISIBLE | WS_CHILD | WS_BORDER | ES_LEFT | ES_AUTOHSCROLL, x, y, width, 20, hWnd, NULL, NULL, NULL);
 }
 
 HWND CreateTextLabel(HWND hWnd, WCHAR* text, int x, int y, int width)
@@ -625,8 +625,8 @@ SendCC()
     bool mp = SendMessage(hModes[1], BM_GETCHECK, 0, 0) == BST_CHECKED;
 
     sockaddr_in sa;
-    char text[1024], remoteAddress[16], remotePort[6];
-    GetWindowTextA(hCCMessage, text, 1024);
+    char text[8192], remoteAddress[16], remotePort[6];
+    GetWindowTextA(hCCMessage, text, 8192);
     GetWindowTextA(hCCRemoteAddress, remoteAddress, 16);
     GetWindowTextA(hCCRemotePort, remotePort, 6);
 
@@ -685,6 +685,7 @@ LRESULT CALLBACK WindowProcedure(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
 
         CreatePushButton(hwnd, L"Send CC", (HMENU)BTN_SEND_CC, 10, 160);
         hCCMessage = CreateEditBox(hwnd, L"hello, dco-win", 150, 160, 120);
+        SendMessage(hCCMessage, EM_SETLIMITTEXT, 10000, 0);
         hCCRemoteAddress = CreateEditBox(hwnd, L"192.168.100.1", 290, 160, 120);
         hCCRemotePort = CreateEditBox(hwnd, L"1194", 430, 160, 60);
 

--- a/ovpn-dco.inf
+++ b/ovpn-dco.inf
@@ -4,6 +4,7 @@ Class=Net
 ClassGuid={4d36e972-e325-11ce-bfc1-08002be10318}
 Provider=%ovpn-dco.CompanyName%
 CatalogFile=ovpn-dco.cat
+PnpLockdown=1
 
 [DestinationDirs]
 DefaultDestDir = 12

--- a/peer.cpp
+++ b/peer.cpp
@@ -345,10 +345,24 @@ OvpnPeerNew(POVPN_DEVICE device, WDFREQUEST request)
 
     GOTO_IF_NOT_NT_SUCCESS(done, status, WdfRequestRetrieveInputBuffer(request, sizeof(OVPN_NEW_PEER), (PVOID*)&peer, nullptr));
 
+    if ((peer->Local.Addr4.sin_family != AF_INET) && (peer->Local.Addr4.sin_family != AF_INET6))
+    {
+        status = STATUS_INVALID_DEVICE_REQUEST;
+        LOG_ERROR("Unknown address family in peer->Local", TraceLoggingValue(peer->Local.Addr4.sin_family, "AF"));
+        goto done;
+    }
+
     if ((peer->Remote.Addr4.sin_family != AF_INET) && (peer->Remote.Addr4.sin_family != AF_INET6))
     {
         status = STATUS_INVALID_DEVICE_REQUEST;
         LOG_ERROR("Unknown address family in peer->Remote", TraceLoggingValue(peer->Remote.Addr4.sin_family, "AF"));
+        goto done;
+    }
+
+    if ((peer->Proto != OVPN_PROTO_UDP) && (peer->Proto != OVPN_PROTO_TCP))
+    {
+        status = STATUS_INVALID_DEVICE_REQUEST;
+        LOG_ERROR("Unknown protocol in peer->Proto", TraceLoggingValue((int)peer->Proto, "Proto"));
         goto done;
     }
 

--- a/socket.cpp
+++ b/socket.cpp
@@ -332,6 +332,11 @@ VOID OvpnSocketDataPacketReceived(_In_ POVPN_DEVICE device, UCHAR op, UINT32 pee
 VOID
 OvpnSocketProcessIncomingPacket(_In_ POVPN_DEVICE device, _In_reads_(packetLength) PUCHAR buf, SIZE_T packetLength, BOOLEAN irqlDispatch, _In_opt_ PSOCKADDR remoteAddr)
 {
+    if (packetLength < OVPN_DATA_V2_LEN) {
+        LOG_ERROR("Packet too short", TraceLoggingValue(packetLength, "len"));
+        return;
+    }
+
     UCHAR op = RtlUlongByteSwap(*(ULONG*)(buf)) >> 24;
     if (OvpnCryptoOpcodeExtract(op) == OVPN_OP_DATA_V2) {
         UINT32 peerId = RtlUlongByteSwap(*(ULONG*)(buf)) & OVPN_PEER_ID_MASK;

--- a/timer.cpp
+++ b/timer.cpp
@@ -51,6 +51,10 @@ WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(OVPN_PEER_TIMER_CONTEXT, OvpnGetPeerTimerCont
 _Use_decl_annotations_
 BOOLEAN OvpnTimerIsKeepaliveMessage(const PUCHAR buf, SIZE_T len)
 {
+    if (len != sizeof(OvpnKeepaliveMessage)) {
+        return FALSE;
+    }
+
     return RtlCompareMemory(buf, OvpnKeepaliveMessage, len) == sizeof(OvpnKeepaliveMessage);
 }
 


### PR DESCRIPTION
Add a length check before calling RtlCompareMemory() to ensure the buffer is at least as large as the keepalive message. This prevents a possible memory over-read if the function is called with a shorter buffer.

Also bump version to 2.5.9.