### PR TITLE
peer: zero OVPN_PEER_STATS output buffer to avoid pool leak

### DIFF
--- a/peer.cpp
+++ b/peer.cpp
@@ -24,6 +24,7 @@
 
 #include "trace.h"
 #include "peer.h"
+#include "peerstats.h"
 #include "timer.h"
 #include "socket.h"
 
@@ -783,11 +784,8 @@ OvpnPeerGetStatsV2(POVPN_DEVICE device, WDFREQUEST request, ULONG_PTR* bytesRetu
         int i = 0;
         while ((ptr = RtlEnumerateGenericTableWithoutSplaying(&device->Peers, &restartKey)) != NULL) {
             OvpnPeerContext* peer = *(OvpnPeerContext**)ptr;
-            outBuf[i].PeerId = peer->PeerId;
-            outBuf[i].LinkRxBytes = peer->LinkRxBytes;
-            outBuf[i].LinkTxBytes = peer->LinkTxBytes;
-            outBuf[i].VpnRxBytes = peer->VpnRxBytes;
-            outBuf[i].VpnTxBytes = peer->VpnTxBytes;
+            OvpnFillPeerStats(&outBuf[i], peer->PeerId, peer->LinkRxBytes,
+                peer->LinkTxBytes, peer->VpnRxBytes, peer->VpnTxBytes);
             ++i;
         }
 
@@ -809,11 +807,8 @@ OvpnPeerGetStatsV2(POVPN_DEVICE device, WDFREQUEST request, ULONG_PTR* bytesRetu
             goto done;
         }
 
-        outBuf->PeerId = peer->PeerId;
-        outBuf->LinkRxBytes = peer->LinkRxBytes;
-        outBuf->LinkTxBytes = peer->LinkTxBytes;
-        outBuf->VpnRxBytes = peer->VpnRxBytes;
-        outBuf->VpnTxBytes = peer->VpnTxBytes;
+        OvpnFillPeerStats(outBuf, peer->PeerId, peer->LinkRxBytes,
+            peer->LinkTxBytes, peer->VpnRxBytes, peer->VpnTxBytes);
 
         OvpnPeerCtxRelease(peer);
 

--- a/peerstats.h
+++ b/peerstats.h
@@ -1,0 +1,54 @@
+/*
+ *  ovpn-dco-win OpenVPN protocol accelerator for Windows
+ *
+ *  Copyright (C) 2024- OpenVPN Inc <sales@openvpn.net>
+ *
+ *  Author:	Lev Stipakov <lev@openvpn.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#if defined(_KERNEL_MODE)
+#include <ntddk.h>
+#include "uapi/ovpn-dco.h"
+#else
+/* uapi/ovpn-dco.h pulls <winsock2.h> first so it must precede <windows.h>,
+ * otherwise windows.h brings in the legacy <winsock.h> and the two collide. */
+#include "uapi/ovpn-dco.h"
+#define WIN32_NO_STATUS
+#include <windows.h>
+#undef WIN32_NO_STATUS
+#endif
+
+/*
+ * Fill one OVPN_PEER_STATS record. The buffer aliases a METHOD_BUFFERED
+ * system buffer that the I/O Manager does NOT zero, and OVPN_PEER_STATS has a
+ * 4-byte alignment hole between PeerId and LinkRxBytes. Zeroing first is what
+ * keeps that hole (and any tail residue) from leaking non-paged pool to user
+ * mode -- do not drop it. Both OvpnPeerGetStats paths funnel through here so
+ * the zero can't be forgotten in one of them.
+ */
+__inline void
+OvpnFillPeerStats(OVPN_PEER_STATS* out, INT32 peerId,
+    LONG64 linkRxBytes, LONG64 linkTxBytes, LONG64 vpnRxBytes, LONG64 vpnTxBytes)
+{
+    RtlZeroMemory(out, sizeof(*out));
+    out->PeerId = peerId;
+    out->LinkRxBytes = linkRxBytes;
+    out->LinkTxBytes = linkTxBytes;
+    out->VpnRxBytes = vpnRxBytes;
+    out->VpnTxBytes = vpnTxBytes;
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -5,6 +5,7 @@
  * (via uapi/ovpn-dco.h) which must be included before <windows.h> brings in
  * the legacy <winsock.h>. crypto_epoch.h includes <windows.h> first. */
 #include "../notifyqueue.h"
+#include "../peerstats.h"
 #include "../crypto_epoch.h"
 
 class CryptoTest : public testing::Test
@@ -362,4 +363,37 @@ TEST(NotifyEventFill, FloatPeerLeavesNoPoolResidue)
     OVPN_DEL_PEER_REASON zeroReason;
     std::memset(&zeroReason, 0, sizeof(zeroReason));
     ASSERT_EQ(0, std::memcmp(&evt.DelPeerReason, &zeroReason, sizeof(zeroReason)));
+}
+
+/* OVPN_PEER_STATS has a 4-byte alignment hole between PeerId (offset 0) and
+ * LinkRxBytes (offset 8). OvpnFillPeerStats writes into an un-zeroed
+ * METHOD_BUFFERED system buffer, so that hole must be zeroed or it leaks
+ * non-paged pool to user mode. Poison first; only field-controlled bytes and
+ * zeros may survive. */
+TEST(PeerStatsFill, LeavesNoPoolResidue)
+{
+    OVPN_PEER_STATS s;
+    std::memset(&s, 0xAB, sizeof(s));
+
+    OvpnFillPeerStats(&s, 5, 100, 200, 300, 400);
+
+    ASSERT_EQ(s.PeerId, 5);
+    ASSERT_EQ(s.LinkRxBytes, 100);
+    ASSERT_EQ(s.LinkTxBytes, 200);
+    ASSERT_EQ(s.VpnRxBytes, 300);
+    ASSERT_EQ(s.VpnTxBytes, 400);
+
+    /* Compare the whole struct against an authoritative zero+fields buffer to
+     * catch the alignment-hole leak (and any other uninitialised padding). */
+    OVPN_PEER_STATS expected;
+    std::memset(&expected, 0, sizeof(expected));
+    expected.PeerId = 5;
+    expected.LinkRxBytes = 100;
+    expected.LinkTxBytes = 200;
+    expected.VpnRxBytes = 300;
+    expected.VpnTxBytes = 400;
+    ASSERT_EQ(0, std::memcmp(&s, &expected, sizeof(s)))
+        << "OvpnFillPeerStats left uninitialised padding (the 4-byte hole "
+           "between PeerId and LinkRxBytes) -- kernel pool leaked to user mode "
+           "in OvpnPeerGetStats.";
 }


### PR DESCRIPTION
OVPN_PEER_STATS has a 4-byte alignment hole between PeerId and LinkRxBytes. Both paths of OvpnPeerGetStats filled the struct field-by-field into the METHOD_BUFFERED system buffer, which is not zero-initialised, leaking non-paged pool residue to an unprivileged local caller (4 bytes per record, multiplied by the peer count on the all-peers path).

Funnel both paths through a new OvpnFillPeerStats helper that zeroes the record before filling it, so the zero can't be forgotten in one path. Add a test that poisons the record, fills it, and compares against a zero+fields buffer to catch the alignment-hole leak.

Jira: OVPN3-1448