### PR TITLE
Fix lost wakeup between the control RX queue and pending reads

### DIFF
--- a/Driver.cpp
+++ b/Driver.cpp
@@ -132,13 +132,29 @@ OvpnEvtIoRead(WDFQUEUE queue, WDFREQUEST request, size_t length)
 
     POVPN_DEVICE device = OvpnGetDeviceContext(WdfIoQueueGetDevice(queue));
 
+    // the dequeue and the parking of the request must be atomic with respect
+    // to OvpnSocketControlPacketReceived(), otherwise a packet enqueued in
+    // between is never handed to userspace: the packet sits in
+    // ControlRxBufferQueue while the request sits in PendingReadsQueue and
+    // neither side re-checks the other
+    KIRQL irql = ExAcquireSpinLockExclusive(&device->ControlRxLock);
+
     // do we have pending control packets?
     LIST_ENTRY* entry = OvpnBufferQueueDequeue(device->ControlRxBufferQueue);
     if (entry == NULL) {
         // no pending control packets, move request to manual queue
-        LOG_IF_NOT_NT_SUCCESS(WdfRequestForwardToIoQueue(request, device->PendingReadsQueue));
+        NTSTATUS forwardStatus = WdfRequestForwardToIoQueue(request, device->PendingReadsQueue);
+        ExReleaseSpinLockExclusive(&device->ControlRxLock, irql);
+        if (!NT_SUCCESS(forwardStatus)) {
+            // the request is owned by neither queue now, so complete it here;
+            // leaving it behind would stall the sequential default queue
+            LOG_ERROR("Failed to forward read request", TraceLoggingNTStatus(forwardStatus, "status"));
+            WdfRequestCompleteWithInformation(request, forwardStatus, 0);
+        }
         return;
     }
+
+    ExReleaseSpinLockExclusive(&device->ControlRxLock, irql);
 
     OVPN_RX_BUFFER* buffer = CONTAINING_RECORD(entry, OVPN_RX_BUFFER, QueueListEntry);
 

--- a/Driver.h
+++ b/Driver.h
@@ -73,6 +73,11 @@ struct OVPN_DEVICE {
     // buffer queue for received control channel packets
     OVPN_BUFFER_QUEUE ControlRxBufferQueue;
 
+    // serializes the (ControlRxBufferQueue, PendingReadsQueue) pair so that a
+    // packet can never be queued while a read request is being parked, and
+    // vice versa
+    EX_SPIN_LOCK ControlRxLock;
+
     // pool for OVPN_RX_BUFFER entries
     OVPN_RX_BUFFER_POOL RxBufferPool;
 

--- a/socket.cpp
+++ b/socket.cpp
@@ -119,7 +119,11 @@ OvpnSocketControlPacketReceived(_In_ POVPN_DEVICE device, _In_reads_(len) PUCHAR
         totalLen += hdrLen;
     }
 
+    // paired with OvpnEvtIoRead(): retrieving a pending read and queueing the
+    // packet must not interleave, or the packet ends up queued behind a
+    // request that has already given up looking for it
     WDFREQUEST request;
+    KIRQL irql = ExAcquireSpinLockExclusive(&device->ControlRxLock);
     NTSTATUS status = WdfIoQueueRetrieveNextRequest(device->PendingReadsQueue, &request);
     if (!NT_SUCCESS(status)) {
         // add control channel packet to queue
@@ -128,6 +132,7 @@ OvpnSocketControlPacketReceived(_In_ POVPN_DEVICE device, _In_reads_(len) PUCHAR
 
         // fetch buffer
         if (!NT_SUCCESS(OvpnRxBufferPoolGet(device->RxBufferPool, &buffer))) {
+            ExReleaseSpinLockExclusive(&device->ControlRxLock, irql);
             LOG_ERROR("RxBufferPool exhausted");
             InterlockedIncrementNoFence(&device->Stats.LostInControlPackets);
             return;
@@ -144,8 +149,10 @@ OvpnSocketControlPacketReceived(_In_ POVPN_DEVICE device, _In_reads_(len) PUCHAR
 
             // enqueue buffer, it will be dequeued when read request arrives
             OvpnBufferQueueEnqueue(device->ControlRxBufferQueue, &buffer->QueueListEntry);
+            ExReleaseSpinLockExclusive(&device->ControlRxLock, irql);
         }
         else {
+            ExReleaseSpinLockExclusive(&device->ControlRxLock, irql);
             LOG_ERROR("Buffer too small, packet len <pktlen>, buf len <buflen>",
                 TraceLoggingValue(totalLen, "pktlen"), TraceLoggingValue(sizeof(buffer->Data), "buflen"));
 
@@ -153,6 +160,8 @@ OvpnSocketControlPacketReceived(_In_ POVPN_DEVICE device, _In_reads_(len) PUCHAR
         }
     }
     else {
+        ExReleaseSpinLockExclusive(&device->ControlRxLock, irql);
+
         // service IO request right away
         PVOID readBuffer;
         size_t readBufferLength;


### PR DESCRIPTION
`OvpnEvtIoRead()` and `OvpnSocketControlPacketReceived()` coordinate through two lock-free structures, but nothing serialises the pair:

```
EvtIoRead:              dequeue(ControlRxBufferQueue)
                        -> empty -> WdfRequestForwardToIoQueue(request, PendingReadsQueue)

ControlPacketReceived:  WdfIoQueueRetrieveNextRequest(PendingReadsQueue)
                        -> none  -> OvpnBufferQueueEnqueue(ControlRxBufferQueue, buffer)
```

Both sides check the other's structure *before* publishing into their own, so the checks can interleave:

1. `EvtIoRead` dequeues, finds the buffer queue empty.
2. A datagram arrives on another CPU; `WdfIoQueueRetrieveNextRequest` fails because the request has not been forwarded yet.
3. The receive path enqueues the buffer.
4. `EvtIoRead` forwards the request to `PendingReadsQueue`.

The buffer now sits in `ControlRxBufferQueue` while a read request sits in `PendingReadsQueue`, and neither side re-checks. Nothing is logged and no stat is bumped — `Stats.LostInControlPackets` is untouched, because from the driver's point of view the packet was not lost.

The packet is released only when the *next* datagram arrives and takes the parked request; that datagram is delivered from the head of the queue, i.e. the older one. From then on userspace is served one control packet behind, indefinitely. A short burst — an ACK immediately followed by the peer's key-exchange flight — is enough to open the window.

This patch takes a new per-device `EX_SPIN_LOCK` around the retrieve/enqueue and dequeue/forward pairs. The lock is held only for the queue operations: request completion and the payload copy stay outside it, and the buffer-pool allocation is non-paged, so nothing here is unsafe at `DISPATCH_LEVEL`, which is where the WSK receive callback can run.

It also completes the read request when `WdfRequestForwardToIoQueue()` fails, instead of only logging. A request that is neither completed nor owned by a queue stalls the sequential default queue (`WdfIoQueueDispatchSequential`, `Driver.cpp`), and with it every subsequent read, write and IOCTL on the device.

### Testing

I want to be upfront: **this patch is not runtime-tested.** I found the race while investigating an unrelated connectivity problem on Windows ARM64, and I have no WDK build environment or test-signing setup to load a self-built driver. The reasoning is from the 2.8.3 sources; the change is small and local, but it deserves a review by someone who can build and stress it — ideally with several control packets arriving back-to-back while a read is being parked.

I am happy to adjust the approach if you would rather re-check both structures after publishing instead of adding a lock.
